### PR TITLE
Gemspec update w.r.t. Readme file

### DIFF
--- a/jasmine_rails.gemspec
+++ b/jasmine_rails.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.summary     = "Makes Jasmine easier on Rails 3.1"
   s.description = "Provides a Jasmine Spec Runner that plays nicely with Rails 3.1 assets and sets up jasmine-headless-webkit"
 
-  s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.rdoc"]
+  s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
 
   s.add_dependency "rails", ">= 3.1.0"
   s.add_dependency "jasmine"


### PR DESCRIPTION
Fix gemspec reference to the README which causes a warning when installing through bundler
