### PR TITLE
Set src_dir to jasmine look for application javascripts  

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Next, edit the generated `spec/javascripts/support/jasmine.yml` file to ensure t
     spec_files:
       - "**/*[Ss]pec.{js,coffee}"
 
-    src_dir:
+    src_dir: app/assets/javascripts
 
     spec_dir: spec/javascripts
 


### PR DESCRIPTION
It was not working when have application assets referenced in application.js manifest file. 
After set the src_dir it works.
