### PR TITLE
Move jasmine.yml into /config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ First, add jasmine-rails to your Gemfile, like so
 
 Next, run `bundle install`.
 
-In order to run any specs, you'll need a Jasmine configuration in `spec/javascripts/support/jasmine.yml`. [Here's an example](https://github.com/searls/jasmine-rails/tree/master/spec/dummy/spec/javascripts/support) from this repo's [dummy project](https://github.com/searls/jasmine-rails/tree/master/spec/dummy).
+In order to run any specs, you'll need a Jasmine configuration in `config/jasmine.yml`. [Here's an example](https://github.com/searls/jasmine-rails/tree/master/spec/dummy/spec/javascripts/support) from this repo's [dummy project](https://github.com/searls/jasmine-rails/tree/master/spec/dummy).
 
 ``` yaml
 src_files:

--- a/lib/jasmine_rails/jhw_adapter.rb
+++ b/lib/jasmine_rails/jhw_adapter.rb
@@ -6,6 +6,7 @@ module JasmineRails
 
     def initialize
       @options = Jasmine::Headless::Options.new
+      @options[:jasmine_config] = 'config/jasmine.yml'
       @runner = Jasmine::Headless::Runner.new(@options)
       Jasmine::Headless::CacheableAction.enabled = @options[:enable_cache]
     end


### PR DESCRIPTION
You might have strong feelings that this config file should stay where it is in which case feel free to ignore this, but for me it makes more sense to put the `jasmine.yml` config file into my app's `/config` folder.

This has two benefits:
1. Jasmine specs can now live in a folder other than `/spec` (e.g. `/test`) and not require an otherwise empty `/spec/javascripts/support` folder.
2. It keeps all of the app's configuration files in the same place.
