### PR TITLE
don't pass out nil paths from calls to asset_paths as that kills app boot

### DIFF
--- a/lib/jasmine_rails/jhw_adapter.rb
+++ b/lib/jasmine_rails/jhw_adapter.rb
@@ -32,7 +32,7 @@ module JasmineRails
         jasmine_config["src_dir"],
         jasmine_config["spec_dir"],
         jasmine_config["asset_paths"]
-      ].flatten
+      ].flatten.compact
     end
 
     def instantiate_runner


### PR DESCRIPTION
Hi. If some paths (e.g. asset_paths) aren't explicitly set in the jasmine.yml, jhw_adapter returns nil paths. This then kills hike downstream, and the entire app boot as a result. I suggest just compacting out the nils at this point. 

What do you reckon?
