### PR TITLE
Enable browser caching

### DIFF
--- a/lib/jasmine_rails/jhw_adapter.rb
+++ b/lib/jasmine_rails/jhw_adapter.rb
@@ -8,6 +8,7 @@ module JasmineRails
       @options = Jasmine::Headless::Options.new
       @runner = instantiate_runner
       Jasmine::Headless::CacheableAction.enabled = @options[:enable_cache]
+      Jasmine::Headless::FilesList.reset!
     end
 
     def css_files


### PR DESCRIPTION
Fixes [issue #23](https://github.com/searls/jasmine-rails/issues/23)

Not sure why it works but I noticed `jasmine-headless-webkit` always calls reset after modifying `Jasmine::Headless::CacheableAction.enabled`.
