### PR TITLE
Fixed phantomjs execution for paths with spaces

### DIFF
--- a/lib/tasks/jasmine-rails_tasks.rake
+++ b/lib/tasks/jasmine-rails_tasks.rake
@@ -21,7 +21,7 @@ namespace :spec do
     runner_path = Rails.root.join('spec/tmp/runner.html')
     File.open(runner_path, 'w') {|f| f << html}
 
-    run_cmd "phantomjs #{File.join(File.dirname(__FILE__), 'runner.js')} file://#{runner_path.to_s}?spec=#{spec_filter}"
+    run_cmd %{phantomjs "#{File.join(File.dirname(__FILE__), 'runner.js')}" "file://#{runner_path.to_s}?spec=#{spec_filter}"}
   end
 
   # alias


### PR DESCRIPTION
Added double-quoting of paths to the arguments passed to phantomjs in the rake task
