### PR TITLE
jasmine-rails should not override the application's assets.debug config

### DIFF
--- a/lib/jasmine_rails/engine.rb
+++ b/lib/jasmine_rails/engine.rb
@@ -5,7 +5,6 @@ module JasmineRails
     isolate_namespace JasmineRails
 
     initializer :assets do |config|
-      Rails.application.config.assets.debug = false
       Rails.application.config.assets.paths << Jasmine::Core.path
       Rails.application.config.assets.paths << JasmineRails.spec_dir
     end


### PR DESCRIPTION
I don't understand why this was being set in the first place. This change seems to work well in our app that has a large amount of javascript tests.
