### PR TITLE
An idea for HTML fixtures 

### DIFF
--- a/app/helpers/jasmine_rails/spec_runner_helper.rb
+++ b/app/helpers/jasmine_rails/spec_runner_helper.rb
@@ -26,5 +26,9 @@ module JasmineRails
       files << 'jasmine-specs.js'
       files
     end
+
+    def jasmine_fixtures
+      JasmineRails.fixtures_enabled and JasmineRails.fixture_files
+    end
   end
 end

--- a/app/views/layouts/jasmine_rails/spec_runner.html.erb
+++ b/app/views/layouts/jasmine_rails/spec_runner.html.erb
@@ -6,6 +6,11 @@
 
     <%= stylesheet_link_tag *jasmine_css_files %>
     <%= javascript_include_tag *jasmine_js_files %>
+    <% if jasmine_fixtures %>
+    <script>
+    var jasmineFixtures = <%=raw jasmine_fixtures.to_json %>;
+    </script>
+    <% end %>
   </head>
   <body>
     <div id="jasmine_content"></div>

--- a/lib/jasmine-rails.rb
+++ b/lib/jasmine-rails.rb
@@ -42,6 +42,20 @@ module JasmineRails
       each_dir src_dir.to_s, &block
     end
 
+    def fixture_files
+      fixtures = {}
+      files = filter_files fixture_dir, ['**/*.html'], true
+      files.each do |file|
+        dir, name = Pathname.new(file).split
+        fixtures[dir.relative_path_from(fixture_dir).join(name.basename('.*')).to_s] = File.read(file).strip
+      end
+      fixtures
+    end
+
+    def fixtures_enabled
+      jasmine_config.has_key?('fixture_dir')
+    end
+
     # clear out cached jasmine config file
     # it would be nice to automatically flush when the jasmine.yml file changes instead
     # of having this programatic API
@@ -54,6 +68,10 @@ module JasmineRails
     def src_dir
       path = jasmine_config['src_dir'] || 'app/assets/javascripts'
       Rails.root.join(path)
+    end
+
+    def fixture_dir
+      Rails.root.join(spec_dir, jasmine_config['fixture_dir'])
     end
 
     def jasmine_config
@@ -73,12 +91,12 @@ module JasmineRails
       end
     end
 
-    def filter_files(root_dir, patterns)
+    def filter_files(root_dir, patterns, absolute = false)
       files = patterns.to_a.collect do |pattern|
         Dir.glob(root_dir.join(pattern)).sort
       end
       files = files.flatten
-      files = files.collect {|f| f.gsub(root_dir.to_s + '/', '') }
+      files = files.collect {|f| f.gsub(root_dir.to_s + '/', '') } unless absolute
       files || []
     end
 

--- a/spec/javascripts/fixtures/foo.html
+++ b/spec/javascripts/fixtures/foo.html
@@ -1,0 +1,1 @@
+<div id="foo" class="fixture"></div>

--- a/spec/javascripts/fixtures/foo/bar.html
+++ b/spec/javascripts/fixtures/foo/bar.html
@@ -1,0 +1,1 @@
+<div id="bar"></div>

--- a/spec/javascripts/fixtures_spec.js
+++ b/spec/javascripts/fixtures_spec.js
@@ -1,0 +1,11 @@
+describe("fixtures", function(){
+  it("can access fixture files", function(){
+    var fixture = jasmineFixtures["foo"];
+    expect(fixture).toEqual('<div id="foo" class="fixture"></div>');
+  });
+
+  it("can access fixture files in subfolders", function(){
+    var fixture = jasmineFixtures["foo/bar"];
+    expect(fixture).toEqual('<div id="bar"></div>');
+  });
+});

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -10,3 +10,5 @@ helpers:
 
 spec_files:
   - "**/*[Ss]pec.{js,coffee}"
+
+fixture_dir: fixtures


### PR DESCRIPTION
The idea is simple: load fixture files from the `fixtures` directory and make them available to specs by adding them to a global fixture hash.
- Enable fixtures by adding a `fixture_dir` setting to the jasmine.yml file.
- A file named foo.html will be available in specs via `jasmineFixtures['foo']`.
- Fixture files can also be organised in subfolders so `foo/bar.html` can be accessed via `jasmineFixtures['foo/bar']`.

This removes the need for unsatisfactory ajax solutions or creating fixtures from scratch using jQuery. The solution is independent from jQuery so spec writers are free to do what they want with them and we could possibly add support for haml fixtures for example.

Comments? What do you think?
