### PR TITLE
tweak to console reporter to use top spec descriptions only

### DIFF
--- a/lib/assets/javascripts/jasmine-console-reporter.js
+++ b/lib/assets/javascripts/jasmine-console-reporter.js
@@ -91,7 +91,7 @@
   };
 
   proto.reportSuiteResults = function(suite) {
-    if (!suite.parentSuite) { return; }
+    if (suite.parentSuite) { return; }
     var results = suite.results();
     if (results.totalCount === 0) {
       return;


### PR DESCRIPTION
I noticed that the console reporter used when running from the command line outputs suite results in a confusing format: it only outputs suite results when the suite has a parent suite. Wouldn't it make more sense to reverse the check so we only output suite results for suites with no parent (essentially one line per spec file).

Consider the following specs:

``` coffeescript
describe 'SomeComponent', ->
  describe 'someMethod', ->
    it 'does something', ->
      ...
```

and

``` coffeescript
describe 'SomeOtherComponent', ->
  describe 'someOtherMethod', ->
    it 'does something', ->
      ...
```

The current console reporter would output the following:

```
Starting...
someMethod: 1 of 1 passed.
someOtherMethod: 1 of 1 passed.

Finished
-----------------
2 specs, 0 failures in x.xxxs.
```

With this small tweak, the output would be:

```
Starting...
SomeComponent: 1 of 1 passed.
SomeOtherComponent: 1 of 1 passed.

Finished
-----------------
2 specs, 0 failures in x.xxxs.
```

Makes more sense right?
