### PR TITLE
Minor documentation tweak

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,9 @@ spec_files:
 You can write a spec to test Foo in `spec/javascripts/foo_spec.js`:
 
 ```javascript
-//= require helpers/spec_helper  (includes spec/javascripts/helpers/spec_helper.js)
-//= require foo                  (includes app/assets/javascripts/foo.js)
+// include spec/javascripts/helpers/spec_helper.js and app/assets/javascripts/foo.js
+//= require helpers/spec_helper
+//= require foo
 describe('Foo', function() {
   it("does something", function() {
     expect(1 + 1).toBe(2);


### PR DESCRIPTION
I got a little tripped up here since I copied and pasted this snippet as a place to start. The error message that rails gives `ArgumentError in JasmineRails::SpecRunner#index` with details of `Showing /path/to/gems/jasmine-rails/app/views/layouts/jasmine_rails/spec_runner.html.erb where line #8 raised:` is slightly misleading (though it does point you to the correct file when describing the error later (`wrong number of arguments (3 for 1) (in /path/to/myapp/spec/javascripts/welcome_spec.js:2)`).

Making this change doesn't really seem to hurt anything and make keep others from making the same mistake.
