### PR TITLE
Avoid clashing with main ApplicationController

### DIFF
--- a/app/controllers/jasmine_rails/spec_runner_controller.rb
+++ b/app/controllers/jasmine_rails/spec_runner_controller.rb
@@ -1,5 +1,5 @@
 module JasmineRails
-  class SpecRunnerController < ApplicationController
+  class SpecRunnerController < JasmineRails::ApplicationController
     def index
       JasmineRails.reload_jasmine_config
     end


### PR DESCRIPTION
The `ApplicationController` of the hosting (a.k.a. main_app) application is being loaded instead of the `JasmineRails::ApplicationController`.

I detect the issue because on the main_app `ApplicationController` route url helpers are called. In the context of the Engine those fail. The experienced behavior is that a 404 is returned due to the `ActionController::RoutingError`.
