### PR TITLE
Allow for jasmine.yml to be in 'config/' instead of 'spec/javascripts/support/'

### DIFF
--- a/lib/jasmine-rails.rb
+++ b/lib/jasmine-rails.rb
@@ -58,7 +58,8 @@ module JasmineRails
 
     def jasmine_config
       @config ||= begin
-        path = Rails.root.join('spec', 'javascripts', 'support', 'jasmine.yml')
+        path = Rails.root.join('config', 'jasmine.yml')      
+        path = Rails.root.join('spec', 'javascripts', 'support', 'jasmine.yml') unless File.exists?(path)
         initialize_jasmine_config_if_absent(path)
         YAML.load_file(path)
       end


### PR DESCRIPTION
While I understand the decision a lot of people are going with MiniTest for Rails 4 projects instead of RSpec. It seems like a good idea to keep the choice test location independent of the configuration file itself.

I'm sure there are other ways this could be handled, more just wanted to get thoughts on the proposal first.
