### PR TITLE
When window.onload is set by test code, phantomjs never exits.

### DIFF
--- a/lib/tasks/runner.js
+++ b/lib/tasks/runner.js
@@ -46,7 +46,7 @@
   // setup listeners for jasmine events
   page.onInitialized = function() {
     return page.evaluate(function() {
-      return window.onload = function() {
+      document.addEventListener('DOMContentLoaded', function() {
         jsApiReporter.exitCode = 0;
         jsApiReporter.reportSpecResults = function(spec) {
           if (spec.results().failedCount > 0) {
@@ -61,7 +61,7 @@
             });
           }, 1);
         };
-      };
+      });
     });
   };
 


### PR DESCRIPTION
I believe jQuery or some other library in my project was overwriting window.onload after the page was loading, so the logic to handle exiting phantom would never be called.

Changing this to use an event listener prevents it from being overridden.
