### PR TITLE
javascripts at the bottom of the <body>

### DIFF
--- a/app/views/layouts/jasmine_rails/spec_runner.html.erb
+++ b/app/views/layouts/jasmine_rails/spec_runner.html.erb
@@ -5,10 +5,10 @@
     <title>Jasmine Specs</title>
 
     <%= stylesheet_link_tag *jasmine_css_files %>
-    <%= javascript_include_tag *jasmine_js_files %>
   </head>
   <body>
     <div id="jasmine_content"></div>
     <%= yield %>
+    <%= javascript_include_tag *jasmine_js_files %>
   </body>
 </html>


### PR DESCRIPTION
I think it's best to include scripts at [the bottom of the body element](http://developer.yahoo.com/performance/rules.html#js_bottom).  My pair and I just had a good time debugging some jasmine tests that depended on (rightly or wrongly) being able to use the body from jQuery when the javascripts are parsed outside of a document.ready().
