### PR TITLE
Better compatible shim for Function.prototype.bind

### DIFF
--- a/lib/assets/javascripts/jasmine-console-shims.js
+++ b/lib/assets/javascripts/jasmine-console-shims.js
@@ -1,31 +1,31 @@
 (function() {
   /**
-   * Function.bind Polyfill for ECMAScript 5 Support
-   * Kangax's bind with Broofa's arg optimization.
-   * http://www.broofa.com/Tools/JSLitmus/tests/PrototypeBind.html
+   * Function.bind for ECMAScript 5 Support
    *
-   * Copied from https://gist.github.com/rxgx/1597825
+   * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind
    */
-  if (typeof Function.prototype.bind !== "function") {
-    Function.prototype.bind = function() {
-      var slice = Array.prototype.slice;
-      return function(context) {
-        var fn = this,
-          args = slice.call(arguments, 1);
-        if (args.length) {
-          return function() {
-            return arguments.length
-              ? fn.apply(context, args.concat(slice.call(arguments)))
-              : fn.apply(context, args);
+
+  if (!Function.prototype.bind) {
+    Function.prototype.bind = function (oThis) {
+      if (typeof this !== "function") {
+        // closest thing possible to the ECMAScript 5 internal IsCallable function
+        throw new TypeError("Function.prototype.bind - what is trying to be bound is not callable");
+      }
+
+      var aArgs = Array.prototype.slice.call(arguments, 1),
+          fToBind = this,
+          fNOP = function () {},
+          fBound = function () {
+            return fToBind.apply(this instanceof fNOP && oThis
+                                   ? this
+                                   : oThis,
+                                 aArgs.concat(Array.prototype.slice.call(arguments)));
           };
-        }
-        return function() {
-          return arguments.length
-            ? fn.apply(context, arguments)
-            : fn.call(context);
-        };
-      };
+
+      fNOP.prototype = this.prototype;
+      fBound.prototype = new fNOP();
+
+      return fBound;
     };
   }
 })();
-


### PR DESCRIPTION
Existing polyfill is not completely compatible and breaks native bind usage in underscore.js
