### PR TITLE
added clarification for require

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ describe('Foo', function() {
   });
 });
 ```
+\*As noted above, spec_helper and foo.js must be required in order for foo_spec.js to run.
 
 ## Running from the command line
 


### PR DESCRIPTION
Hi Justin,

I emailed you a few weeks back about not being able to run specs. It was really obvious, but I (and some others) missed the fact that spec files need require spec_helper and the file tested.

Even though you have it in your example, I added an extra note on the README that tells the user to require:

*As noted above, spec_helper and foo.js must be required in order for foo_spec.js to run.

If you think it's too obvious and not change the README, I get it. I just thought that some others may run into the same problem. Either way, it's an easy gem to work with.

Thanks
Nick
