### PR TITLE
Fixes `bundle install` now that Rails v4.x is live

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gemspec
 gem 'testbeds'
 
 # Gems used by the dummy application
+gem 'rails', '~> 4.0'
 gem "jquery-rails"
 gem "sqlite3"
 gem 'coffee-script'


### PR DESCRIPTION
For some reason bundler gets confused with the existing dependencies
but this sets it straight.

Each testbed still passes successfully (even the Rails v3.1 and v3.2)
