### PR TITLE
Only run rails 4 tests a single time from the command line

### DIFF
--- a/lib/jasmine_rails/offline_asset_paths.rb
+++ b/lib/jasmine_rails/offline_asset_paths.rb
@@ -25,7 +25,13 @@ module JasmineRails
 
       FileUtils.mkdir_p File.dirname(source_path)
       Rails.logger.debug "Compiling #{source} to #{source_path}"
-      File.open(source_path, 'w') {|f| f << content }
+      File.open(source_path, 'w') do |f|
+        if Rails::VERSION::MAJOR == 4 && !Rails.env.test? && source == 'jasmine-specs.js'
+          f << ''
+        else
+          f << content
+        end
+      end
       "/assets/#{source}"
     end
 


### PR DESCRIPTION
I don't know why sprockets wants to concatonate all files in rails 4
but this will explicitly write an empty file for jasmine-specs.js
which stops the duplicate test runs.

This is extremely hackish, but I can't find a way around this.

Fixes https://github.com/searls/jasmine-rails/issues/28
