### PR TITLE
point travis to our little shell script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,6 @@ before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
 
-before_script:
-  - mkdir -p spec/testbeds
-  # only if you don't commit the testbeds to git
-  - bundle exec generate-testbeds
+install: ''
 
-bundler_args: ''
-
-# run all tests in the context of the testbed represented by the
-# current gemfile
-script: "rake testbed:current:all"
-
-gemfile:
-  - gemfiles/rails-3.1
-  - gemfiles/rails-3.2
-  - gemfiles/rails-4.0
+script: "./run-tests.sh"


### PR DESCRIPTION
Now that I've got this little shell script to get up-and-running and to run each suite, may as well have travis point to it instead of encoding the same instructions in two places.
