### PR TITLE
open file to write with binary flag

### DIFF
--- a/lib/jasmine_rails/offline_asset_paths.rb
+++ b/lib/jasmine_rails/offline_asset_paths.rb
@@ -25,7 +25,7 @@ module JasmineRails
 
       FileUtils.mkdir_p File.dirname(source_path)
       Rails.logger.debug "Compiling #{source} to #{source_path}"
-      File.open(source_path, 'w') do |f|
+      File.open(source_path, 'wb') do |f|
         if Rails::VERSION::MAJOR == 4 && !Rails.env.test? && source == 'jasmine-specs.js'
           f << ''
         else


### PR DESCRIPTION
This fix will handle issues where image_path is used within a .js.erb file. This fix stops jasmine-rails from throwing a "ASCII-8BIT to UTF-8" error.

Related to issue: https://github.com/searls/jasmine-rails/issues/64
