### PR TITLE
removed file:// from command run, windows does not recognise this prefix...

### DIFF
--- a/lib/jasmine_rails/runner.rb
+++ b/lib/jasmine_rails/runner.rb
@@ -13,7 +13,7 @@ module JasmineRails
           File.open(runner_path, 'w') {|f| f << html.gsub('/assets', './assets')}
 
           phantomjs_runner_path = File.join(File.dirname(__FILE__), '..', 'assets', 'javascripts', 'jasmine-runner.js')
-          run_cmd %{phantomjs "#{phantomjs_runner_path}" "file://#{runner_path.to_s}?spec=#{spec_filter}"}
+          run_cmd %{phantomjs "#{phantomjs_runner_path}" "#{runner_path.to_s}?spec=#{spec_filter}"}
         end
       end
 


### PR DESCRIPTION
I had an issue using jasmine-rails in a Windows environment. I found removing the file:// fixed the issue for me. I tested this on a Mac and the runner still works without the file://
