### PR TITLE
asset_path helper in tests fail due to computed path being hardcoded

### DIFF
--- a/lib/jasmine_rails/offline_asset_paths.rb
+++ b/lib/jasmine_rails/offline_asset_paths.rb
@@ -21,7 +21,8 @@ module JasmineRails
       source = source.to_s
       return source if source.starts_with?('/')
       content = Rails.application.assets[source].to_s
-      source_path = JasmineRails.tmp_dir.join('assets').join(source)
+      asset_prefix = Rails.configuration.assets.prefix.gsub(/\A\//,'')
+      source_path = JasmineRails.tmp_dir.join(asset_prefix).join(source)
 
       FileUtils.mkdir_p File.dirname(source_path)
       Rails.logger.debug "Compiling #{source} to #{source_path}"
@@ -32,7 +33,7 @@ module JasmineRails
           f << content
         end
       end
-      "/assets/#{source}"
+      "/#{asset_prefix}/#{source}"
     end
 
   end

--- a/lib/jasmine_rails/runner.rb
+++ b/lib/jasmine_rails/runner.rb
@@ -10,7 +10,8 @@ module JasmineRails
           include_offline_asset_paths_helper
           html = get_spec_runner(spec_filter)
           runner_path = JasmineRails.tmp_dir.join('runner.html')
-          File.open(runner_path, 'w') {|f| f << html.gsub('/assets', './assets')}
+          asset_prefix = Rails.configuration.assets.prefix.gsub(/\A\//,'')
+          File.open(runner_path, 'w') {|f| f << html.gsub("/#{asset_prefix}", "./#{asset_prefix}")}
 
           phantomjs_runner_path = File.join(File.dirname(__FILE__), '..', 'assets', 'javascripts', 'jasmine-runner.js')
           run_cmd %{phantomjs "#{phantomjs_runner_path}" "#{runner_path.to_s}?spec=#{spec_filter}"}


### PR DESCRIPTION
The computed offline asset path and by association the jasmine runner
fail because the asset path is hard-coded to /assets rather than using
Rails.configuration.assets.prefix
