### PR TITLE
Add support for config.force_ssl

### DIFF
--- a/lib/jasmine-rails.rb
+++ b/lib/jasmine-rails.rb
@@ -55,6 +55,11 @@ module JasmineRails
       @config = nil
     end
 
+    # force ssl when loading the test runner. Set to true if your app forces SSL
+    def force_ssl
+      jasmine_config['force_ssl'] || false
+    end
+
     private
 
     def src_dir

--- a/lib/jasmine_rails/runner.rb
+++ b/lib/jasmine_rails/runner.rb
@@ -53,6 +53,7 @@ module JasmineRails
 
       def get_spec_runner(spec_filter)
         app = ActionDispatch::Integration::Session.new(Rails.application)
+        app.https!(JasmineRails.force_ssl)
         path = JasmineRails.route_path
         JasmineRails::OfflineAssetPaths.disabled = false
         app.get path, :console => 'true', :spec => spec_filter


### PR DESCRIPTION
When loading the spec runner from the app, support HTTPS only app by calling `.https!` on the `ActionDispatch::Integration::Session`. 

Also added a configuration option for it to the `jasmine.yml` file, defaulting to `false`.
