### PR TITLE
ConsoleReporter displays failure message (yet exits with status code 0) if tests are marked as pending

### DIFF
--- a/lib/assets/javascripts/jasmine-console-reporter.js
+++ b/lib/assets/javascripts/jasmine-console-reporter.js
@@ -36,7 +36,8 @@
     stopped : "stopped",
     running : "running",
     fail    : "fail",
-    success : "success"
+    success : "success",
+    skipped_or_pending : "skipped or pending"
   };
 
   proto.reportRunnerStarting = proto.jasmineStarted = function(runner) {
@@ -44,20 +45,23 @@
     this.start_time = (new Date()).getTime();
     this.executed_specs = 0;
     this.passed_specs = 0;
+    this.skipped_or_pending_specs = 0;
     this.log("Starting...");
   };
 
   proto.reportRunnerResults = proto.jasmineDone = function(runner) {
-    var failed = this.executed_specs - this.passed_specs;
+    var failed = this.executed_specs - this.passed_specs - this.skipped_or_pending_specs;
     var spec_str = this.executed_specs + (this.executed_specs === 1 ? " spec, " : " specs, ");
     var fail_str = failed + (failed === 1 ? " failure in " : " failures in ");
+    var skipped_or_pending_str = this.skipped_or_pending_specs ? this.skipped_or_pending_specs + ' skipped or pending, ' : '';
+
     var color = (failed > 0)? "red" : "green";
     var dur = (new Date()).getTime() - this.start_time;
 
     this.log("");
     this.log("Finished");
     this.log("-----------------");
-    this.log(spec_str + fail_str + (dur/1000) + "s.", color);
+    this.log(spec_str + skipped_or_pending_str + fail_str + (dur/1000) + "s.", color);
 
     this.status = (failed > 0)? this.statuses.fail : this.statuses.success;
 
@@ -75,6 +79,7 @@
     if(spec.results) { //jasmine 1.x
       var specResult = spec.results()
       if(specResult.skipped) {
+        this.skipped_or_pending_specs++;
         return;
       } else if(specResult.passed()) {
         this.passed_specs++;
@@ -85,6 +90,7 @@
         this.passed_specs++;
         return;
       } else if(spec.status !== "failed") {
+        this.skipped_or_pending_specs++;
         //Skipped or Pending
         return;
       }


### PR DESCRIPTION
# Problem

The `reportRunnerResults` method on the `ConsoleReporter` computes the total number of failed specs thusly:

``` javascript
proto.reportRunnerResults = proto.jasmineDone = function(runner) {
  var failed = this.executed_specs - this.passed_specs;
  // ...
}
```

Since the `executed_specs` property is incremented via a call to `specDone` (from jasmine.js) when a spec is run, the value of `failed` will be non-zero if any specs had a status not equal to `passed`. The code in jasmine-runner.js, however, passes PhantomJS a status code of 1 only if one or more specs have been marked as `failed`. This combination causes the test suite to pass (from a status code perspective) while the ConsoleReporter displays a failure message.

``` javascript
if(jsApiReporter.specs) {
  jsApiReporter.specs().forEach(function(spec) {
    if(spec.status === "failed") {
      exitCode = 1;
    }
  })
}

setTimeout(function() {
  window.callPhantom({
    event: 'exit',
    exitCode: exitCode
  });
}, 1);
```
# Solution

This patch introduces a new status `skipped_or_pending` and corresponding counter that is incremented when `specDone` is called and the spec has not been marked as a success or failure. The value of `failed` consumes the value of this counter. The final message displayed to the user now communicates if any tests were `pending` or `skipped`.
