### PR TITLE
Add support for CSS files in Jasmine suite

### DIFF
--- a/Bedfile
+++ b/Bedfile
@@ -23,6 +23,7 @@ testbeds do
       f.puts <<-end_bootstrap
         Rails.application.config.assets.paths << "#{fixtures}/app/assets/javascripts"
         Rails.application.config.assets.paths << "#{fixtures}/vendor/assets/javascripts"
+        Rails.application.config.assets.paths << "#{fixtures}/app/assets/stylesheets"
       end_bootstrap
     end
   end

--- a/app/helpers/jasmine_rails/spec_runner_helper.rb
+++ b/app/helpers/jasmine_rails/spec_runner_helper.rb
@@ -7,7 +7,9 @@ module JasmineRails
     # includes:
     # * core jasmine css files
     def jasmine_css_files
-      Jasmine::Core.css_files
+      files = Jasmine::Core.css_files
+      files << 'jasmine-specs.css'
+      files
     end
 
     # return list of javascript files needed for jasmine testsuite

--- a/lib/assets/stylesheets/jasmine-specs.css.erb
+++ b/lib/assets/stylesheets/jasmine-specs.css.erb
@@ -1,0 +1,14 @@
+<%
+  # depend on spec dirs to automatically flush asset cache
+  # when new tests or directories are added
+  JasmineRails.each_spec_dir do |directory|
+    depend_on directory
+  end
+
+  # bundle all jasmine css using asset pipeline
+  # so asset pipeline can properly filter out duplicates
+  # via dependency tree
+  JasmineRails.css_files.each do |file|
+    require_asset(file.to_s)
+  end
+%>

--- a/lib/generators/jasmine_rails/templates/jasmine.yml
+++ b/lib/generators/jasmine_rails/templates/jasmine.yml
@@ -3,10 +3,19 @@
 # defaults to app/assets/javascripts
 src_dir: "app/assets/javascripts"
 
+# path to parent directory of css_files
+# relative path from Rails.root
+# defaults to app/assets/stylesheets
+css_dir: "app/assets/stylesheets"
+
 # list of file expressions to include as source files
 # relative path from src_dir
 src_files:
  - "application.{js.coffee,js,coffee}"
+
+# list of file expressions to include as css files
+# relative path from css_dir
+css_files:
 
 # path to parent directory of spec_files
 # relative path from Rails.root

--- a/lib/jasmine-rails.rb
+++ b/lib/jasmine-rails.rb
@@ -42,10 +42,19 @@ module JasmineRails
       files
     end
 
+    # return a list of any additional CSS files to be included into the jasmine testsuite
+    def css_files
+      files = []
+      files += filter_files css_dir, jasmine_config['css_files']
+      files += filter_files spec_dir, jasmine_config['css_files']
+      files
+    end
+
     # iterate over all directories used as part of the testsuite (including subdirectories)
     def each_spec_dir(&block)
       each_dir spec_dir.to_s, &block
       each_dir src_dir.to_s, &block
+      each_dir css_dir.to_s, &block
     end
 
     # clear out cached jasmine config file
@@ -61,6 +70,11 @@ module JasmineRails
     end
 
     private
+
+    def css_dir
+      path = jasmine_config['css_dir'] || 'app/assets/stylesheets'
+      Rails.root.join(path)
+    end
 
     def src_dir
       path = jasmine_config['src_dir'] || 'app/assets/javascripts'

--- a/spec/fixtures/app/assets/stylesheets/support.css
+++ b/spec/fixtures/app/assets/stylesheets/support.css
@@ -1,0 +1,1 @@
+.hide { display: none; }

--- a/spec/javascripts/stuff/stylesheets_spec.coffee
+++ b/spec/javascripts/stuff/stylesheets_spec.coffee
@@ -1,0 +1,7 @@
+describe 'stylesheets', ->
+
+  beforeEach ->
+    @div = affix('.hide')
+
+  it 'should include specified stylesheets', ->
+    expect( @div.is(':visible') ).not.toBeTruthy()

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -1,7 +1,11 @@
 src_dir: "../../fixtures/app/assets/javascripts"
+css_dir: "../../fixtures/app/assets/stylesheets"
 
 src_files:
  - "application.{js,coffee}"
+
+css_files:
+ - "support.{css,css.sass}"
 
 spec_dir: ../../javascripts
 


### PR DESCRIPTION
Adds the ability to include application.css or other supporting CSS files into the Jasmine test suite. This is especially helpful if you are migrating from Jasminerails and/or have tests that assert functional behavior of CSS classes.
