### PR TITLE
Fix README references to SpecRunnerHelper

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,7 @@ Create a custom layout in app/views/layouts/jasmine_rails/spec_runner.html.erb a
 If you wanted to do something like this using [requirejs-rails](https://github.com/jwhitley/requirejs-rails), your helper
 might look like this:
 
-```
-
+```ruby
 # in lib/jasmine_rails/spec_helper.rb
 module JasmineRails
   module SpecHelper


### PR DESCRIPTION
Implementing your own SpecRunnerHelper will override the builtin JasmineRails::SpecRunnerHelper. JasmineRails::SpecRunnerController actually tries to load JasmineRails::SpecHelper, but the documentation erroneously refers to SpecRunnerHelper.
