### PR TITLE
Replace Function.prototype.bind polyfill with one that works for the latest version of Phantomjs

### DIFF
--- a/lib/assets/javascripts/jasmine-console-shims.js
+++ b/lib/assets/javascripts/jasmine-console-shims.js
@@ -1,31 +1,38 @@
+// using react's Function.prototype.bind polyfill for phantomjs
+// https://github.com/facebook/react/blob/master/src/test/phantomjs-shims.js
+
 (function() {
-  /**
-   * Function.bind for ECMAScript 5 Support
-   *
-   * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind
-   */
 
-  if (!Function.prototype.bind) {
-    Function.prototype.bind = function (oThis) {
-      if (typeof this !== "function") {
-        // closest thing possible to the ECMAScript 5 internal IsCallable function
-        throw new TypeError("Function.prototype.bind - what is trying to be bound is not callable");
-      }
+var Ap = Array.prototype;
+var slice = Ap.slice;
+var Fp = Function.prototype;
 
-      var aArgs = Array.prototype.slice.call(arguments, 1),
-          fToBind = this,
-          fNOP = function () {},
-          fBound = function () {
-            return fToBind.apply(this instanceof fNOP && oThis
-                                   ? this
-                                   : oThis,
-                                 aArgs.concat(Array.prototype.slice.call(arguments)));
-          };
+if (!Fp.bind) {
+  // PhantomJS doesn't support Function.prototype.bind natively, so
+  // polyfill it whenever this module is required.
+  Fp.bind = function(context) {
+    var func = this;
+    var args = slice.call(arguments, 1);
 
-      fNOP.prototype = this.prototype;
-      fBound.prototype = new fNOP();
+    function bound() {
+      var invokedAsConstructor = func.prototype && (this instanceof func);
+      return func.apply(
+        // Ignore the context parameter when invoking the bound function
+        // as a constructor. Note that this includes not only constructor
+        // invocations using the new keyword but also calls to base class
+        // constructors such as BaseClass.call(this, ...) or super(...).
+        !invokedAsConstructor && context || this,
+        args.concat(slice.call(arguments))
+      );
+    }
 
-      return fBound;
-    };
-  }
+    // The bound function must share the .prototype of the unbound
+    // function so that any object created by one constructor will count
+    // as an instance of both constructors.
+    bound.prototype = func.prototype;
+
+    return bound;
+  };
+}
+
 })();


### PR DESCRIPTION
The Function.prototype.bind polyfill used does not work with Phantomjs. Get the following error locally:

```
ERROR: TypeError: instanceof called on an object with an invalid prototype property.
TRACE:
...../jasmine/assets/jasmine-console-shims.js: 19
```

People had the same issue here: https://github.com/facebook/react/issues/945
React's polyfill for Function.prototype.bind addresses the issue.

This pull request is for replacing the existing polyfill, which looks it was copied from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind#Compatibility
with the one from React.js located at https://github.com/facebook/react/blob/master/src/test/phantomjs-shims.js

Alternatively, I could just fix the existing polyfill instead of replacing it, to make the diff smaller. Let me know what is preferable.
