### PR TITLE
Turn off for turbolinks

### DIFF
--- a/app/views/layouts/jasmine_rails/spec_runner.html.erb
+++ b/app/views/layouts/jasmine_rails/spec_runner.html.erb
@@ -7,7 +7,7 @@
     <%= stylesheet_link_tag *jasmine_css_files %>
     <%= javascript_include_tag *jasmine_js_files %>
   </head>
-  <body>
+  <body data-no-turbolink>
     <div id="jasmine_content"></div>
     <%= yield %>
   </body>


### PR DESCRIPTION
For the body element, so that all assets are loaded and links work ok
