### PR TITLE
Protect against nil source in offline_asset_paths

### DIFF
--- a/lib/jasmine_rails/offline_asset_paths.rb
+++ b/lib/jasmine_rails/offline_asset_paths.rb
@@ -19,7 +19,7 @@ module JasmineRails
     def compute_public_path_with_offline_asset(source, dir, options={})
       return compute_public_path_without_offline_asset(source, dir, options) if JasmineRails::OfflineAssetPaths.disabled
       source = source.to_s
-      return source if source.starts_with?('/')
+      return source if source.empty? || source.starts_with?('/')
       content = Rails.application.assets[source].to_s
       asset_prefix = Rails.configuration.assets.prefix.gsub(/\A\//,'')
       source_path = JasmineRails.tmp_dir.join(asset_prefix).join(source)


### PR DESCRIPTION
The monkey-patched offline asset path stuff was receiving a nil 'source' argument in our app and crashing before writing the assets and runner.html. It seems prudent to just ignore these. (This PR fixes the problem for us).

FWIW the line in our code that seemed to be triggering this was this:

```
"#{ActionController::Base.asset_host}#{ActionController::Base.helpers.asset_path(self.checkout_image)}",
```

I think in this case self.checkout_image is nil.
