### PR TITLE
Getting Requirejs to properly do its thing with Jasmine

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# This is an RVM Project .rvmrc file, used to automatically load the ruby
+# development environment upon cd'ing into the directory
+
+# First we specify our desired <ruby>[@<gemset>], the @gemset name is optional,
+# Only full ruby name is supported here, for short names use:
+#     echo "rvm use ree" > .rvmrc
+environment_id="ruby-1.9.3-p327-falcon@jasmine-rails"
+
+# Uncomment the following lines if you want to verify rvm version per project
+# rvmrc_rvm_version="1.17.3 (stable)" # 1.10.1 seams as a safe start
+# eval "$(echo ${rvm_version}.${rvmrc_rvm_version} | awk -F. '{print "[[ "$1*65536+$2*256+$3" -ge "$4*65536+$5*256+$6" ]]"}' )" || {
+#   echo "This .rvmrc file requires at least RVM ${rvmrc_rvm_version}, aborting loading."
+#   return 1
+# }
+
+# First we attempt to load the desired environment directly from the environment
+# file. This is very fast and efficient compared to running through the entire
+# CLI and selector. If you want feedback on which environment was used then
+# insert the word 'use' after --create as this triggers verbose mode.
+if [[ -d "${rvm_path:-$HOME/.rvm}/environments"
+  && -s "${rvm_path:-$HOME/.rvm}/environments/$environment_id" ]]
+then
+  \. "${rvm_path:-$HOME/.rvm}/environments/$environment_id"
+  [[ -s "${rvm_path:-$HOME/.rvm}/hooks/after_use" ]] &&
+    \. "${rvm_path:-$HOME/.rvm}/hooks/after_use" || true
+  if [[ $- == *i* ]] # check for interactive shells
+  then echo "Using: $(tput setaf 2)$GEM_HOME$(tput sgr0)" # show the user the ruby and gemset they are using in green
+  else echo "Using: $GEM_HOME" # don't use colors in non-interactive shells
+  fi
+else
+  # If the environment file has not yet been created, use the RVM CLI to select.
+  rvm --create use  "$environment_id" || {
+    echo "Failed to create RVM environment '${environment_id}'."
+    return 1
+  }
+fi
+
+# If you use bundler, this might be useful to you:
+# if [[ -s Gemfile ]] && {
+#   ! builtin command -v bundle >/dev/null ||
+#   builtin command -v bundle | GREP_OPTIONS= \grep $rvm_path/bin/bundle >/dev/null
+# }
+# then
+#   printf "%b" "The rubygem 'bundler' is not installed. Installing it now.\n"
+#   gem install bundler
+# fi
+# if [[ -s Gemfile ]] && builtin command -v bundle >/dev/null
+# then
+#   bundle install | GREP_OPTIONS= \grep -vE '^Using|Your bundle is complete'
+# fi

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'rails', '~> 4.0'
 gem "jquery-rails"
 gem "sqlite3"
 gem 'coffee-script'
+gem 'capybara'
 
 group :test do
   gem 'rspec-rails'

--- a/README.md
+++ b/README.md
@@ -180,35 +180,29 @@ end
 
 Remove any reference to `src_files` in `spec/javascripts/support/jasmine.yml`, to ensure files aren't loaded prematurely.
 
-Create your custom layout `app/views/layouts/jasmine_rails/spec_runner.html.erb` like so:
-```erb
+The new default layout is designed to allow requirejs to do its job. The only change now required is to enable the custom rjs-boot.js
 
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta content="text/html;charset=UTF-8" http-equiv="Content-Type"/>
-    <title>Jasmine Specs</title>
-
-    <%= stylesheet_link_tag *jasmine_css_files %>
-    <%= requirejs_include_tag %>
-    <%= javascript_include_tag *jasmine_js_files %>
-  </head>
-  <body>
-    <div id="jasmine_content"></div>
-    <%= yield %>
-  </body>
-</html>
-
+```yaml
+# in spec/javascripts/support/jasmine.yml
+# Uncomment the following:
+support_dir: "spec/javascripts/support"
+boot_script: "rjs-boot.js"
 ```
 
-Use require with a callback to load your components:
+Use require to any test dependencies.
 
-```coffeescript
+```javascript
+// spec/javascripts/my-module.spec.js
 
-describe 'test my module', ->
-  require ['my/module'], (Module) ->
-    it 'does something', ->
-      expect(Module.method).toEqual 'something'
+define([
+  'my/module'
+], function (myModule) {
+  describe('test my module', function() {
+    it('Should...', function (){
+      ...
+    });
+  });
+});
 ```
 
 ### Custom Reporter

--- a/app/helpers/jasmine_rails/spec_runner_helper.rb
+++ b/app/helpers/jasmine_rails/spec_runner_helper.rb
@@ -23,16 +23,29 @@ module JasmineRails
       files = Jasmine::Core.js_files
       files << jasmine_boot_file
       files += JasmineRails.reporter_files params[:reporters]
-      files << 'jasmine-specs.js'
+      files << 'jasmine-specs.js' unless requirejs_spec_loading?
       files
     end
 
+    def jasmine_spec_files
+      JasmineRails.spec_files
+    end
+
     def jasmine_boot_file
-      if jasmine2?
+      if JasmineRails.custom_boot
+        JasmineRails.custom_boot
+
+      elsif jasmine2?
         Jasmine::Core.boot_files.first
+
       else
         'jasmine-boot.js'
+
       end
+    end
+
+    def requirejs_spec_loading?
+      defined?(Requirejs) ? true : false
     end
 
     def jasmine2?

--- a/app/views/layouts/jasmine_rails/spec_runner.html.erb
+++ b/app/views/layouts/jasmine_rails/spec_runner.html.erb
@@ -10,5 +10,15 @@
   <body data-no-turbolink>
     <div id="jasmine_content"></div>
     <%= yield %>
+
+    <%= requirejs_include_tag if requirejs_spec_loading? %>
+    <% if requirejs_spec_loading? %>
+      <script type="text/javascript">
+      // jshint ignore: start
+        require(<%= jasmine_spec_files.map { |file| "#{javascript_path file}"}.to_s.html_safe %>, function (){
+          window.executeTests();
+        });
+      </script>
+    <% end %>
   </body>
 </html>

--- a/lib/generators/jasmine_rails/install_generator.rb
+++ b/lib/generators/jasmine_rails/install_generator.rb
@@ -11,6 +11,10 @@ module JasmineRails
         template "jasmine.yml", "spec/javascripts/support/jasmine.yml"
       end
 
+      def create_rjs_boot_js
+        template "rjs-boot.js", "spec/javascripts/support/rjs-boot.js"
+      end
+
       def add_routes
         route "mount JasmineRails::Engine => '/specs' if defined?(JasmineRails)"
       end

--- a/lib/generators/jasmine_rails/templates/jasmine.yml
+++ b/lib/generators/jasmine_rails/templates/jasmine.yml
@@ -48,3 +48,8 @@ spec_files:
 # (spec runner and asset cache)
 # defaults to tmp/jasmine
 tmp_dir: "tmp/jasmine"
+
+# Custom jasmine boot.js
+# (optional)
+#support_dir: "spec/javascripts/support"
+#boot_script: "rjs-boot.js"

--- a/lib/generators/jasmine_rails/templates/rjs-boot.js
+++ b/lib/generators/jasmine_rails/templates/rjs-boot.js
@@ -1,0 +1,138 @@
+/*
+Copyright (c) 2008-2014 Pivotal Labs
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+/**
+ Starting with version 2.0, this file "boots" Jasmine, performing all of the necessary initialization before executing the loaded environment and all of a project's specs. This file should be loaded after `jasmine.js` and `jasmine_html.js`, but before any project source files or spec files are loaded. Thus this file can also be used to customize Jasmine for a project.
+
+ If a project is using Jasmine via the standalone distribution, this file can be customized directly. If a project is using Jasmine via the [Ruby gem][jasmine-gem], this file can be copied into the support directory via `jasmine copy_boot_js`. Other environments (e.g., Python) will have different mechanisms.
+
+ The location of `boot.js` can be specified and/or overridden in `jasmine.yml`.
+
+ [jasmine-gem]: http://github.com/pivotal/jasmine-gem
+ */
+
+(function() {
+
+  /**
+   * ## Require &amp; Instantiate
+   *
+   * Require Jasmine's core files. Specifically, this requires and attaches all of Jasmine's code to the `jasmine` reference.
+   */
+  window.jasmine = jasmineRequire.core(jasmineRequire);
+
+  /**
+   * Since this is being run in a browser and the results should populate to an HTML page, require the HTML-specific Jasmine code, injecting the same reference.
+   */
+  jasmineRequire.html(jasmine);
+
+  /**
+   * Create the Jasmine environment. This is used to run all specs in a project.
+   */
+  var env = jasmine.getEnv();
+
+  /**
+   * ## The Global Interface
+   *
+   * Build up the functions that will be exposed as the Jasmine public interface. A project can customize, rename or alias any of these functions as desired, provided the implementation remains unchanged.
+   */
+  var jasmineInterface = jasmineRequire.interface(jasmine, env);
+
+  /**
+   * Add all of the Jasmine global/public interface to the proper global, so a project can use the public interface directly. For example, calling `describe` in specs instead of `jasmine.getEnv().describe`.
+   */
+  if (typeof window == "undefined" && typeof exports == "object") {
+    extend(exports, jasmineInterface);
+  } else {
+    extend(window, jasmineInterface);
+  }
+
+  /**
+   * ## Runner Parameters
+   *
+   * More browser specific code - wrap the query string in an object and to allow for getting/setting parameters from the runner user interface.
+   */
+
+  var queryString = new jasmine.QueryString({
+    getWindowLocation: function() { return window.location; }
+  });
+
+  var catchingExceptions = queryString.getParam("catch");
+  env.catchExceptions(typeof catchingExceptions === "undefined" ? true : catchingExceptions);
+
+  /**
+   * ## Reporters
+   * The `HtmlReporter` builds all of the HTML UI for the runner page. This reporter paints the dots, stars, and x's for specs, as well as all spec names and all failures (if any).
+   */
+  var htmlReporter = new jasmine.HtmlReporter({
+    env: env,
+    onRaiseExceptionsClick: function() { queryString.setParam("catch", !env.catchingExceptions()); },
+    getContainer: function() { return document.body; },
+    createElement: function() { return document.createElement.apply(document, arguments); },
+    createTextNode: function() { return document.createTextNode.apply(document, arguments); },
+    timer: new jasmine.Timer()
+  });
+
+  /**
+   * The `jsApiReporter` also receives spec results, and is used by any environment that needs to extract the results  from JavaScript.
+   */
+  env.addReporter(jasmineInterface.jsApiReporter);
+  env.addReporter(htmlReporter);
+
+  /**
+   * Filter which specs will be run by matching the start of the full name against the `spec` query param.
+   */
+  var specFilter = new jasmine.HtmlSpecFilter({
+    filterString: function() { return queryString.getParam("spec"); }
+  });
+
+  env.specFilter = function(spec) {
+    return specFilter.matches(spec.getFullName());
+  };
+
+  /**
+   * Setting up timing functions to be able to be overridden. Certain browsers (Safari, IE 8, phantomjs) require this hack.
+   */
+  window.setTimeout = window.setTimeout;
+  window.setInterval = window.setInterval;
+  window.clearTimeout = window.clearTimeout;
+  window.clearInterval = window.clearInterval;
+
+  /**
+   * ## Execution
+   *
+   * No onload, only on demand now
+   */
+
+  window.executeTests = function(){
+    htmlReporter.initialize();
+    env.execute();
+  };
+
+  /**
+   * Helper function for readability above.
+   */
+  function extend(destination, source) {
+    for (var property in source) destination[property] = source[property];
+    return destination;
+  }
+
+}());

--- a/lib/jasmine-rails.rb
+++ b/lib/jasmine-rails.rb
@@ -36,6 +36,11 @@ module JasmineRails
       Rails.root.join(path)
     end
 
+    def support_dir
+      paths = jasmine_config['support_dir'] || 'support_dir'
+      [paths].flatten.collect { |path| Rails.root.join(path) }
+    end
+
     def reporter_files(types_string)
       types = types_string.to_s.split(',')
 
@@ -89,6 +94,11 @@ module JasmineRails
     # force ssl when loading the test runner. Set to true if your app forces SSL
     def force_ssl
       jasmine_config['force_ssl'] || false
+    end
+
+    def custom_boot
+      return false if jasmine_config['boot_script'] == nil
+      jasmine_config['boot_script']
     end
 
     private

--- a/lib/jasmine_rails/engine.rb
+++ b/lib/jasmine_rails/engine.rb
@@ -5,7 +5,7 @@ module JasmineRails
     isolate_namespace JasmineRails
 
     initializer :assets do |config|
-      [Jasmine::Core.path, JasmineRails.include_dir, JasmineRails.spec_dir].flatten.compact.each do |dir|
+      [Jasmine::Core.path, JasmineRails.include_dir, JasmineRails.spec_dir, JasmineRails.support_dir].flatten.compact.each do |dir|
         Rails.application.config.assets.paths << dir
       end
       Rails.application.config.assets.precompile += %w(jasmine.css boot.js jasmine-boot.js json2.js jasmine.js jasmine-html.js jasmine-console-shims.js jasmine-console-reporter.js jasmine-specs.js jasmine-specs.css)


### PR DESCRIPTION
...onsole.

Changes:
    Added capybara as a dependency
    Modified spec_runner_helper.rb
    Adjusted the way jasmine_js_files method loads in the event that requirejs is in use.
    Added access to the JasmineRails spec_files.
    Checking for a custom boot js and loading it in place of the other boot scripts.
    Modified spec_runner.html.erb
    Added logic to use requirejs if loaded. Set to load all specs as require deps.
    Modified jasmine-rails.rb
    Added support_dir to allow the boot.js to be defined next to the jasmine.yml
    Added custom_boot method to define the boot.js
    Modified install_generator.rb
    Added the creation of the rjs-boot.js
    Modified jasmine.yml
    Added support for custom boot.js
    Added rjs-boot.js
    Copied from Jasmine-core and modified to correctly work with requirejs
    Modified engine.rb
    Added the support path to the asset path
    Modified runner.rb
    Big changes here...
    If requirejs is defined we need to handle things a little differently here... we need to start up a server and allow requirejs and asset pipeline to do what they do.
    Trying to preload assets with requirejs is a nightmare and the only way to attempt it would be to run the requirejs optimizer (r.js) and that will potentially change the code that we are wanting to test.
