### PR TITLE
fix failed count in ConsoleReporter when there are skipped_or_pending_specs

### DIFF
--- a/lib/assets/javascripts/jasmine-console-reporter.js
+++ b/lib/assets/javascripts/jasmine-console-reporter.js
@@ -50,7 +50,7 @@
   };
 
   proto.reportRunnerResults = proto.jasmineDone = function(runner) {
-    var failed = this.executed_specs - this.passed_specs - this.skipped_or_pending_specs;
+    var failed = this.executed_specs - this.passed_specs;
     var spec_str = this.executed_specs + (this.executed_specs === 1 ? " spec, " : " specs, ");
     var fail_str = failed + (failed === 1 ? " failure in " : " failures in ");
     var skipped_or_pending_str = this.skipped_or_pending_specs ? this.skipped_or_pending_specs + ' skipped or pending, ' : '';


### PR DESCRIPTION
The `failures` output in ConsoleReporter is incorrect if `skipped_or_pending_specs` is greater than 0.

Running:

```
rake spec:javascripts SPEC=myspec
```

Before:

```
4 specs, 2081 skipped or pending, -2081 failures in 0.43s.
```

After:

```
4 specs, 2081 skipped or pending, 0 failures in 0.43s.
```

Verified that it works if you run the whole test suite and if there is a failure.
