### PR TITLE
revert PR #150 - was causing incorrect failed count when pending or skipped specs are present

### DIFF
--- a/lib/assets/javascripts/jasmine-console-reporter.js
+++ b/lib/assets/javascripts/jasmine-console-reporter.js
@@ -50,7 +50,7 @@
   };
 
   proto.reportRunnerResults = proto.jasmineDone = function(runner) {
-    var failed = this.executed_specs - this.passed_specs;
+    var failed = this.executed_specs - this.passed_specs - this.skipped_or_pending_specs;
     var spec_str = this.executed_specs + (this.executed_specs === 1 ? " spec, " : " specs, ");
     var fail_str = failed + (failed === 1 ? " failure in " : " failures in ");
     var skipped_or_pending_str = this.skipped_or_pending_specs ? this.skipped_or_pending_specs + ' skipped or pending, ' : '';


### PR DESCRIPTION
Revert https://github.com/searls/jasmine-rails/pull/150, apparently it was an issue in my environment and not in `jasmine-rails`.
