### PR TITLE
Add option to not use the PhantomJS gem executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,3 +237,16 @@ default, and you can explicitly use it by the name `console`.
 See [jasmine-junitreporter][j-junit] for an example with JUnit output.
 
 [j-junit]: https://github.com/shepmaster/jasmine-junitreporter-gem
+
+## PhantomJS binary
+
+By default the [PhantomJS gem](https://github.com/colszowka/phantomjs-gem) will
+be responsible for finding and using an appropriate version of PhantomJS. If
+however, you wish to manage your own phantom executable you can set:
+
+```yml
+use_phantom_gem: false
+```
+
+This will then try and use the `phantom` executable on the current `PATH`.
+

--- a/lib/jasmine-rails.rb
+++ b/lib/jasmine-rails.rb
@@ -91,6 +91,11 @@ module JasmineRails
       jasmine_config['force_ssl'] || false
     end
 
+    # use the phantom command from the phantom gem. Set to false if you want to manage your own phantom executable
+    def use_phantom_gem?
+      jasmine_config['use_phantom_gem'].nil? || jasmine_config['use_phantom_gem'] == true
+    end
+
     private
 
     def css_dir

--- a/lib/jasmine_rails/runner.rb
+++ b/lib/jasmine_rails/runner.rb
@@ -7,7 +7,7 @@ module JasmineRails
       # raises an exception if any errors are encountered while running the testsuite
       def run(spec_filter = nil, reporters = 'console')
         override_rails_config do
-          require 'phantomjs'
+          require 'phantomjs' if JasmineRails.use_phantom_gem?
           require 'fileutils'
 
           include_offline_asset_paths_helper
@@ -18,7 +18,8 @@ module JasmineRails
           File.open(runner_path, 'w') {|f| f << html.gsub("/#{asset_prefix}", "./#{asset_prefix}")}
 
           phantomjs_runner_path = File.join(File.dirname(__FILE__), '..', 'assets', 'javascripts', 'jasmine-runner.js')
-          run_cmd %{"#{Phantomjs.path}" "#{phantomjs_runner_path}" "#{runner_path.to_s}?spec=#{spec_filter}"}
+          phantomjs_cmd = JasmineRails.use_phantom_gem? ? Phantomjs.path : 'phantomjs'
+          run_cmd %{"#{phantomjs_cmd}" "#{phantomjs_runner_path}" "#{runner_path.to_s}?spec=#{spec_filter}"}
         end
       end
 


### PR DESCRIPTION
The PhantomJS gem will automatically download and install a copy of
PhantomJS. The download and installation is over http and without a
checksum, which poses a security risk.

Maintains current default behaviour of downloading and will only skip
the download if the config option is set.

I believe this will resolve https://github.com/searls/jasmine-rails/issues/133