### PR TITLE
Properly exit PhantomJS when running from command line

### DIFF
--- a/lib/assets/javascripts/jasmine-console-reporter.js
+++ b/lib/assets/javascripts/jasmine-console-reporter.js
@@ -69,6 +69,17 @@
        like PhantomJs know when to terminate. */
     this.log("");
     this.log("ConsoleReporter finished");
+    if (this.status == "success") {
+      window.callPhantom({
+        event: 'exit',
+        exitCode: 0
+      });
+    } else if (this.status == "fail") {
+      window.callPhantom({
+        event: 'exit',
+        exitCode: 1
+      });
+    };
   };
 
   proto.reportSpecStarting = proto.specStarted = function(spec) {


### PR DESCRIPTION
I added some success and failure handling to quit out of PhantomJS once the specs are done running. This issue was manifesting itself if I ran `rake spec:javascript` from the command line. Note: I am on a Windows PC, but I don't think that would matter here. 

This fixes #155. 