### PR TITLE
Added ability to change host for spec runner app

### DIFF
--- a/lib/jasmine-rails.rb
+++ b/lib/jasmine-rails.rb
@@ -96,6 +96,11 @@ module JasmineRails
       jasmine_config['use_phantom_gem'].nil? || jasmine_config['use_phantom_gem'] == true
     end
 
+    # change the host for the test runner
+    def host
+      jasmine_config['host'] || 'localhost'
+    end
+
     private
 
     def css_dir

--- a/lib/jasmine_rails/runner.rb
+++ b/lib/jasmine_rails/runner.rb
@@ -55,6 +55,7 @@ module JasmineRails
       def get_spec_runner(spec_filter, reporters)
         app = ActionDispatch::Integration::Session.new(Rails.application)
         app.https!(JasmineRails.force_ssl)
+        app.host = JasmineRails.host
         path = JasmineRails.route_path
         JasmineRails::OfflineAssetPaths.disabled = false
         app.get path, :reporters => reporters, :spec => spec_filter


### PR DESCRIPTION
I have a rails 3.2 app and when running jasmine from console it fails with `Jasmine runner at '/specs' returned a 301 error: Moved Permanently` when I debugged into runner and noticed that it makes redirect to `example.com` and it turns out that [ActionDispatch::Integration::Session](http://api.rubyonrails.org/classes/ActionDispatch/Integration/Session.html) has default host `www.example.com` and changing it to `localhost` fixed it.

I'm not really sure if this affects anyone else, but I've seen this kind of error in some other issues to. Also I had problems to run tests, maybe I used wrong ruby version, tried so far with 2.0 and 2.2.
