### PR TITLE
Ensure `RAILS_ENV` is set to `test` when running tests

### DIFF
--- a/gemfiles/rails-3.2
+++ b/gemfiles/rails-3.2
@@ -15,5 +15,6 @@ group :test do
   gem 'capybara'
   gem 'poltergeist'
   gem 'pry'
+  gem 'test-unit'
 end
 

--- a/lib/tasks/jasmine-rails_tasks.rake
+++ b/lib/tasks/jasmine-rails_tasks.rake
@@ -2,6 +2,10 @@ namespace :spec do
 
   desc "run test with phantomjs"
   task :javascript => [:environment] do
+    unless Rails.env.test?
+      system('RAILS_ENV=test bundle exec rake spec:javascript')
+      next
+    end
     require 'jasmine_rails/runner'
     spec_filter = ENV['SPEC']
     reporters = ENV.fetch('REPORTERS', 'console')


### PR DESCRIPTION
Addresses searls/jasmine-rails#121 - In brief, a recurring source of issues has been forgetting to set `RAILS_ENV` to `test` before running the `spec:javascript` task. This is an implementation of a solution proposed in the issue discussion, namely a guard check to see if the environment is correct and (if it isn't) launch the task again in the correct environment.