### PR TITLE
Pass options to phantomjs executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,3 +249,14 @@ use_phantom_gem: false
 ```
 
 This will then try and use the `phantom` executable on the current `PATH`.
+
+## PhantomJS command-line options
+
+If you want to pass command-line options to phantomjs executable, you can set:
+
+```yml
+phantom_options: --web-security=no
+```
+
+This will pass everything defined on `phantom_options` as
+[options](http://phantomjs.org/api/command-line.html).

--- a/lib/jasmine-rails.rb
+++ b/lib/jasmine-rails.rb
@@ -96,6 +96,10 @@ module JasmineRails
       jasmine_config['use_phantom_gem'].nil? || jasmine_config['use_phantom_gem'] == true
     end
 
+    def phantom_options
+      jasmine_config['phantom_options'].to_s.strip
+    end
+
     private
 
     def css_dir

--- a/lib/jasmine_rails/runner.rb
+++ b/lib/jasmine_rails/runner.rb
@@ -19,7 +19,8 @@ module JasmineRails
 
           phantomjs_runner_path = File.join(File.dirname(__FILE__), '..', 'assets', 'javascripts', 'jasmine-runner.js')
           phantomjs_cmd = JasmineRails.use_phantom_gem? ? Phantomjs.path : 'phantomjs'
-          run_cmd %{"#{phantomjs_cmd}" "#{phantomjs_runner_path}" "file://#{runner_path.to_s}?spec=#{spec_filter}"}
+          phantomjs_opts = JasmineRails.phantom_options
+          run_cmd %{"#{phantomjs_cmd}" "#{phantomjs_opts}" "#{phantomjs_runner_path}" "file://#{runner_path.to_s}?spec=#{spec_filter}"}
         end
       end
 


### PR DESCRIPTION
If someone want to pass a custom option to phantomjs executable, the only way is
making phantomjs gem optional. This PR adds a config `phantom_options` allowing
custom command-line options for phantom