### PR TITLE
Add another space to src_files list in jasmine.yml

### DIFF
--- a/lib/generators/jasmine_rails/templates/jasmine.yml
+++ b/lib/generators/jasmine_rails/templates/jasmine.yml
@@ -17,7 +17,7 @@ css_dir: "app/assets/stylesheets"
 # list of file expressions to include as source files
 # relative path from src_dir
 src_files:
- - "application.{js.coffee,js,coffee}"
+  - "application.{js.coffee,js,coffee}"
 
 # list of file expressions to include as css files
 # relative path from css_dir


### PR DESCRIPTION
Very minor change, but when adding a new item to the list my text editor
seems to get confused by the single space here.