### PR TITLE
spec_runner: target the current version of IE

### DIFF
--- a/app/views/layouts/jasmine_rails/spec_runner.html.erb
+++ b/app/views/layouts/jasmine_rails/spec_runner.html.erb
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta content="text/html;charset=UTF-8" http-equiv="Content-Type"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <title>Jasmine Specs</title>
 
     <%= stylesheet_link_tag *jasmine_css_files %>


### PR DESCRIPTION
Without this, IE9 would run in quirks mode, giving IE8-type "isArray" errors with React.

More details: http://stackoverflow.com/a/29828955/6962