### PR TITLE
Allow passing config yaml file name from environment

### DIFF
--- a/lib/jasmine-rails.rb
+++ b/lib/jasmine-rails.rb
@@ -114,8 +114,9 @@ module JasmineRails
 
     def jasmine_config
       @config ||= begin
-        path = Rails.root.join('config', 'jasmine.yml')
-        path = Rails.root.join('spec', 'javascripts', 'support', 'jasmine.yml') unless File.exists?(path)
+        config_file_name = ENV['JASMINE_CONFIG'] || 'jasmine.yml'
+        path = Rails.root.join('config', config_file_name)
+        path = Rails.root.join('spec', 'javascripts', 'support', config_file_name) unless File.exists?(path)
         initialize_jasmine_config_if_absent(path)
         require 'yaml'
         YAML.load_file(path)


### PR DESCRIPTION
Hey humans,

It would be great if one could pass a custom yml file instead of the default one. Scenarios include having a separate `application.js` for legacy code and a current one.

If you do have a custom yml file then you would simply need to add the environment variable from the console before firing up the test from the web or otherwise.

`RAILS_ENV=test JASMINE_CONFIG=jasmine_legacy.yml bundle exec rake spec:javascript`
or 
`JASMINE_CONFIG=jasmine_legacy.yml bundle exec rails server`

WDYT?