### PR TITLE
preserve exit code when running specs in non-test env

### DIFF
--- a/lib/tasks/jasmine-rails_tasks.rake
+++ b/lib/tasks/jasmine-rails_tasks.rake
@@ -8,7 +8,8 @@ namespace :spec do
       reporters = ENV.fetch('REPORTERS', 'console')
       JasmineRails::Runner.run spec_filter, reporters
     else
-      system("RAILS_ENV=test bundle exec rake #{ARGV.join(' ')}")
+      system('RAILS_ENV=test bundle exec rake spec:javascript')
+      exit($?.exitstatus) if $?.exitstatus != 0
     end
   end
 


### PR DESCRIPTION
We recently picked up the 0.12.0 branch.  I noticed that you merged in this fix by @rudyjahchan https://github.com/searls/jasmine-rails/commit/4691ac7c9554eb49c3867c8223e4a9f5e74f511f with the tiny change hands the full set of ARGV to rake.   That seems a little strange given that this task is supposed to be running only the javascript tests so if I run rake with any other tasks included, they'll get run twice.

`rake spec spec:javascripts`

will run the `spec` task twice before running `spec:javascripts`.

I also found that the exit code is not preserved so if you were counting on this command to trigger something else (while not in test mode) like

`rake spec spec:javascripts && cap deploy acceptance`

this would deploy code even if the JS tests failed.  

This commit adjusts the rake call in non-test mode to call only the `spec:javascripts` and adds a bit of logic to properly handle a failing exit code.