### PR TITLE
JRuby issue fix for bundle exec spec:javascript

### DIFF
--- a/lib/tasks/jasmine-rails_tasks.rake
+++ b/lib/tasks/jasmine-rails_tasks.rake
@@ -8,8 +8,7 @@ namespace :spec do
       reporters = ENV.fetch('REPORTERS', 'console')
       JasmineRails::Runner.run spec_filter, reporters
     else
-      system('RAILS_ENV=test bundle exec rake spec:javascript')
-      exit($?.exitstatus) if $?.exitstatus != 0
+      exec('bundle exec rake spec:javascript RAILS_ENV=test')
     end
   end
 


### PR DESCRIPTION
 fix weird behaviour for jruby - output disappear from screen
 appear on jruby 1.7.16.1 only when you type bundle exec spec:javascript
 without RAILS_ENV=test in the begining. with RAILS_ENV=test it working..

Resolves #177