### PR TITLE
Prevent multiple calls to phantom.exit

### DIFF
--- a/lib/assets/javascripts/jasmine-runner.js
+++ b/lib/assets/javascripts/jasmine-runner.js
@@ -44,8 +44,14 @@
   page.onError = errorHandler;
 
   // setup listeners for jasmine events
+  var initialized = false;
   page.onInitialized = function() {
-    return page.evaluate(function() {
+    if (initialized) {
+      return;
+    }
+
+    initialized = true;
+    page.evaluate(function() {
       return window.onload = function() {
         var exitCode = 0,
             originalReportSpecResults = jsApiReporter.reportSpecResults,

--- a/spec/jasmine_spec.rb
+++ b/spec/jasmine_spec.rb
@@ -23,7 +23,7 @@ end
 describe "Jasmine" do
   specify do
     visit '/specs'
-    find('.bar.passed,.bar.passingAlert')
+    find('.bar.passingAlert,.bar.passed,.jasmine-bar.jasmine-passed')
   end
 end
 


### PR DESCRIPTION
Currently, using jasmine-rails with phantomjs 2.1.1 causes phantomjs to
segfault. It appears that the onInitialized handler registered in
libe/assets/javascripts/jasmine-runner.js:48 is being executed multiple
times. Each call registers a window.onLoad listener which eventually
calls phantom.exit. It is unclear why page.onInitialized is called more
than once.

This commit introduces an initialized flag which prevents the
page.onInitialized callback from registering more than one window.onLoad
callback.

Not an ideal fix. It would be better to figure out what causes
page.onInitialized to be executed multiple times.