### PR TITLE
Work around PhantomJS 2 memory consumption issue

### DIFF
--- a/lib/assets/javascripts/jasmine-runner.js
+++ b/lib/assets/javascripts/jasmine-runner.js
@@ -91,7 +91,16 @@
   var address = args[1];
   console.log('Running: ' + address);
   page.open(address, function(status) {
-    if (status !== "success") {
+    if (status === "success") {
+      // PhantomJS 2 has a memory consumption problem. This works around it.
+      //
+      // http://stackoverflow.com/questions/24436460
+      // https://github.com/ariya/phantomjs/issues/10357
+      // https://github.com/ariya/phantomjs/commit/5768b705a0
+      if (page.clearMemoryCache) {
+        setInterval(page.clearMemoryCache, 500)
+      }
+    } else {
       console.log("can't load the address!");
       return phantom.exit(1);
     }


### PR DESCRIPTION
http://stackoverflow.com/questions/24436460
https://github.com/ariya/phantomjs/issues/10357
https://github.com/ariya/phantomjs/commit/5768b705a0

Without this change, PhantomJS 2 consumes all available memory (at least 8 GB) with our test suite.