### PR TITLE
Fix JasmineRails.spec_files for Sprockets 4

### DIFF
--- a/lib/jasmine-rails.rb
+++ b/lib/jasmine-rails.rb
@@ -57,6 +57,12 @@ module JasmineRails
         files += filter_files dir, jasmine_config['helpers']
         files += filter_files dir, jasmine_config['spec_files']
       end
+
+      # Sprockets 4 wants "logical paths" not to include file extensions
+      if defined?(Sprockets) && Sprockets::VERSION.to_f >= 4
+        files = files.map { |f| f.chomp(File.extname f) }
+      end
+
       files
     end
 


### PR DESCRIPTION
The version check might be unnecessary - this might be safe to do on earlier versions of Sprockets, too. But I know leaving the extensions works up through Sprockets 3, and I don't have quick access to a Sprockets 2 test environment.