### PR TITLE
Allow globbing in spec_dir in jasmine.yml

### DIFF
--- a/lib/jasmine-rails.rb
+++ b/lib/jasmine-rails.rb
@@ -23,7 +23,7 @@ module JasmineRails
 
     def spec_dir
       paths = jasmine_config['spec_dir'] || 'spec/javascripts'
-      [paths].flatten.collect { |path| Rails.root.join(path) }
+      [paths].flatten.map { |path| Dir.glob path }.flatten.collect { |path| Rails.root.join(path) }
     end
 
     def include_dir

--- a/run-tests.rb
+++ b/run-tests.rb
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+require 'fileutils'
+
 def run(cmd)
   system(cmd)
   raise "`#{cmd}` exited non-zero (#{$?}). Exiting." if $? != 0
@@ -9,6 +11,8 @@ puts '<--- Creating app'
 run 'rm -rf example-app'
 run 'bundle exec rails new example-app --skip-gemfile --skip-bundle'
 Dir.chdir('example-app')
+run 'bundle exec rails plugin new myengine --full --skip-gemspec'
+FileUtils.mkdir_p 'myengine/spec/javascripts'
 
 puts '<--- Preparing app'
 run 'rails g jasmine_rails:install'

--- a/run-tests.rb
+++ b/run-tests.rb
@@ -11,8 +11,8 @@ puts '<--- Creating app'
 run 'rm -rf example-app'
 run 'bundle exec rails new example-app --skip-gemfile --skip-bundle'
 Dir.chdir('example-app')
-run 'bundle exec rails plugin new myengine --full --skip-gemspec'
-FileUtils.mkdir_p 'myengine/spec/javascripts'
+run 'bundle exec rails plugin new engines/myengine --full --skip-gemspec'
+FileUtils.mkdir_p 'engines/myengine/spec/javascripts'
 
 puts '<--- Preparing app'
 run 'rails g jasmine_rails:install'

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -9,7 +9,7 @@ css_files:
 
 spec_dir: 
   - "../spec/javascripts"
-  - "../*/spec/javascripts"
+  - "../engines/*/spec/javascripts"
 
 helpers:
   - "helpers/**/*.{js,coffee}"

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -7,7 +7,9 @@ src_files:
 css_files:
  - "support.{css,css.sass}"
 
-spec_dir: ../spec/javascripts
+spec_dir: 
+  - "../spec/javascripts"
+  - "../*/spec/javascripts"
 
 helpers:
   - "helpers/**/*.{js,coffee}"


### PR DESCRIPTION
* For consistency with other config options that allow globbing (e.g. `helpers`, `spec_files`)
* To make it easier to add spec directories that follow a common naming convention (e.g. in engines)