### PR TITLE
Remove Rails 5 request spec params deprecation

### DIFF
--- a/lib/jasmine_rails/runner.rb
+++ b/lib/jasmine_rails/runner.rb
@@ -58,7 +58,13 @@ module JasmineRails
         app.https!(JasmineRails.force_ssl)
         path = JasmineRails.route_path
         JasmineRails::OfflineAssetPaths.disabled = false
-        app.get path, :reporters => reporters, :spec => spec_filter
+
+        if Rails::VERSION::MAJOR >= 5
+          app.get path, :params => { :reporters => reporters, :spec => spec_filter }
+        else
+          app.get path, :reporters => reporters, :spec => spec_filter
+        end
+
         JasmineRails::OfflineAssetPaths.disabled = true
         unless app.response.success?
           raise "Jasmine runner at '#{path}' returned a #{app.response.status} error: #{app.response.message} \n\n" +


### PR DESCRIPTION
Removes deprecations of the form:

```
DEPRECATION WARNING: ActionDispatch::IntegrationTest HTTP request
methods will accept only
the following keyword arguments in future Rails versions:
params, headers, env, xhr, as

Examples:

get '/profile',
  params: { id: 1 },
  headers: { 'X-Extra-Header' => '123' },
  env: { 'action_dispatch.custom' => 'custom' },
  xhr: true,
  as: :json
```