### PR TITLE
Updated `rake spec:javascript` so it doesn't short circuit

### DIFF
--- a/lib/tasks/jasmine-rails_tasks.rake
+++ b/lib/tasks/jasmine-rails_tasks.rake
@@ -8,7 +8,9 @@ namespace :spec do
       reporters = ENV.fetch('REPORTERS', 'console')
       JasmineRails::Runner.run spec_filter, reporters
     else
-      exec('bundle exec rake spec:javascript RAILS_ENV=test')
+      unless system('bundle exec rake spec:javascript RAILS_ENV=test')
+        exit $?.exitstatus
+      end
     end
   end
 


### PR DESCRIPTION
Updated `rake spec:javascript` so it doesn't short circuit a chain of rake tasks by using `exec`.

Fixes https://github.com/searls/jasmine-rails/issues/199