### PR TITLE
Ability to run specific specs

### DIFF
--- a/app/helpers/jasmine_rails/spec_runner_helper.rb
+++ b/app/helpers/jasmine_rails/spec_runner_helper.rb
@@ -23,7 +23,11 @@ module JasmineRails
       files = Jasmine::Core.js_files
       files << jasmine_boot_file
       files += JasmineRails.reporter_files params[:reporters]
-      files += JasmineRails.spec_files
+      if JasmineRails.files_to_run
+        files += JasmineRails.spec_files
+      else
+        files << 'jasmine-specs.js'
+      end
       files
     end
 

--- a/app/helpers/jasmine_rails/spec_runner_helper.rb
+++ b/app/helpers/jasmine_rails/spec_runner_helper.rb
@@ -23,7 +23,7 @@ module JasmineRails
       files = Jasmine::Core.js_files
       files << jasmine_boot_file
       files += JasmineRails.reporter_files params[:reporters]
-      files << 'jasmine-specs.js'
+      files += JasmineRails.spec_files
       files
     end
 

--- a/lib/jasmine-rails.rb
+++ b/lib/jasmine-rails.rb
@@ -5,6 +5,7 @@ module JasmineRails
   CONSOLE_REPORTERS = {'console' => ['jasmine-console-shims.js',
                                      'jasmine-console-reporter.js']}
   class << self
+    attr_accessor :files_to_run
     # return the relative path to access the spec runner
     # for the host Rails application
     # ex: /jasmine
@@ -51,11 +52,15 @@ module JasmineRails
     # * spec helpers
     # * spec_files
     def spec_files
-      files = []
-      files += filter_files src_dir, jasmine_config['src_files']
-      spec_dir.each do |dir|
-        files += filter_files dir, jasmine_config['helpers']
-        files += filter_files dir, jasmine_config['spec_files']
+      if files_to_run
+        files = files_to_run
+      else
+        files = []
+        files += filter_files src_dir, jasmine_config['src_files']
+        spec_dir.each do |dir|
+          files += filter_files dir, jasmine_config['helpers']
+          files += filter_files dir, jasmine_config['spec_files']
+        end
       end
 
       # Sprockets 4 wants "logical paths" not to include file extensions

--- a/lib/tasks/jasmine-rails_tasks.rake
+++ b/lib/tasks/jasmine-rails_tasks.rake
@@ -6,9 +6,17 @@ namespace :spec do
       require 'jasmine_rails/runner'
       spec_filter = ENV['SPEC']
       reporters = ENV.fetch('REPORTERS', 'console')
-      JasmineRails::Runner.run spec_filter, reporters
+      begin
+        if ARGV.length > 1
+          JasmineRails.files_to_run = ARGV.drop(1)
+          JasmineRails.files_to_run.each{|i| task(i.to_sym) {} }
+        end
+        JasmineRails::Runner.run spec_filter, reporters
+      ensure
+        JasmineRails.files_to_run = nil
+      end
     else
-      exec('bundle exec rake spec:javascript RAILS_ENV=test')
+      exec("RAILS_ENV=test bundle exec rake spec:javascript #{ARGV.drop(1).join(" ")}")
     end
   end
 


### PR DESCRIPTION
I figured I would pass this WIP along. I modified this for use at work.

This allows you to specify specific files run run when running via the command line

`bundle exec rake spec:javascript path/to/file_spec.rb path/to/other_spec.rb`

where the path is relative to a asset loading dir.  I wanted this feature so guard can run the specs one or two at a time.

This may have been possible using the existing SPEC filter, but I wasn't sure. Either way I'm passing this along for future consideration.