### PR TITLE
Remove alias_method_chains for OfflineAssetPaths

### DIFF
--- a/lib/jasmine_rails/offline_asset_paths.rb
+++ b/lib/jasmine_rails/offline_asset_paths.rb
@@ -5,19 +5,9 @@
 module JasmineRails
   module OfflineAssetPaths
     mattr_accessor :disabled
-    extend ActiveSupport::Concern
-    included do
-      if ::Rails::VERSION::MAJOR >= 4
-        alias_method :compute_public_path, :compute_asset_path
-        alias_method :compute_asset_path_with_offline_asset, :compute_public_path_with_offline_asset
-        alias_method_chain :compute_asset_path, :offline_asset
-      end
 
-      alias_method_chain :compute_public_path, :offline_asset
-    end
-
-    def compute_public_path_with_offline_asset(source, dir, options={})
-      return compute_public_path_without_offline_asset(source, dir, options) if JasmineRails::OfflineAssetPaths.disabled
+    def compute_asset_path(source, dir, options={})
+      return super if JasmineRails::OfflineAssetPaths.disabled
       source = source.to_s
       return source if source.empty? || source.starts_with?('/')
       content = Rails.application.assets[source].to_s
@@ -34,6 +24,11 @@ module JasmineRails
         end
       end
       "/#{asset_prefix}/#{source}"
+    end
+
+    # For Rails 3.2 support
+    def compute_public_path(*args)
+      JasmineRails::OfflineAssetPaths.disabled ? super : compute_asset_path(*args)
     end
 
   end

--- a/lib/jasmine_rails/runner.rb
+++ b/lib/jasmine_rails/runner.rb
@@ -10,7 +10,7 @@ module JasmineRails
           require 'phantomjs' if JasmineRails.use_phantom_gem?
           require 'fileutils'
 
-          include_offline_asset_paths_helper
+          prepend_offline_asset_paths_helper
           html = get_spec_runner(spec_filter, reporters)
           FileUtils.mkdir_p JasmineRails.tmp_dir
           runner_path = JasmineRails.tmp_dir.join('runner.html')
@@ -25,12 +25,9 @@ module JasmineRails
       end
 
       private
-      def include_offline_asset_paths_helper
-        if Rails::VERSION::MAJOR >= 4
-          Sprockets::Rails::Helper.send :include, JasmineRails::OfflineAssetPaths
-        else
-          ActionView::AssetPaths.send :include, JasmineRails::OfflineAssetPaths
-        end
+      def prepend_offline_asset_paths_helper
+        action_view = Rails::VERSION::MAJOR >= 4 ? ActionView::Base : ActionView::AssetPaths
+        action_view.send :prepend, JasmineRails::OfflineAssetPaths
       end
 
       # temporarily override internal rails settings for the given block


### PR DESCRIPTION
Closes #187 

`#alias_method_chain` is deprecated in Rails 5. Use Ruby 2's `#prepend` instead.

AFAIK this should cap off Rails 5 support with #198. The other warnings in the related issue I assume are just from the example app.

I do not use jasmine-rails, so I would recommend someone with a bit more knowledge actually give this a try - especially with Rails 3, as I just checked the 3.2 stable branch and noted the class/method name change that was done from that version. Also I'm not sure what `Sprockets::Rails::Helper` actually referred to. But I believe it was being included somewhere else anyway (Probably Base), so a prepend to that won't work anymore anyway, hence my use of Base.