### PR TITLE
Adding license info to the Gemspec.

### DIFF
--- a/jasmine-rails.gemspec
+++ b/jasmine-rails.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.homepage    = "http://github.com/searls/jasmine-rails"
   s.summary     = "Makes Jasmine easier on Rails 3.2 & up"
   s.description = "Provides a Jasmine Spec Runner that plays nicely with Rails 3.2 assets and sets up jasmine-headless-webkit"
+  s.license     = "MIT"
 
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
 


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com). If the license information is in the gemspec it will be published via the RubyGems API and that makes it easier for VersionEye and other OS vendors to read the actual license of the project. 