### PR TITLE
PhantomJS (2.1.1) crashes when the url is not followed by a newline

### DIFF
--- a/lib/assets/javascripts/jasmine-runner.js
+++ b/lib/assets/javascripts/jasmine-runner.js
@@ -8,7 +8,7 @@
         msgStack.push(' -> ' + t.file + ': ' + t.line + (t.function ? ' (in function "' + t.function + '")' : ''));
       });
     }
-    console.error(msgStack.join('\n'));
+    require("system").stderr.write(msgStack.join('\n'));
     phantom.exit(1);
   };
   phantom.onError = errorHandler;

--- a/lib/assets/javascripts/jasmine-runner.js
+++ b/lib/assets/javascripts/jasmine-runner.js
@@ -90,7 +90,7 @@
 
   var address = args[1];
   console.log('Running: ' + address);
-  page.open(address, function(status) {
+  page.open(address + '\n', function(status) {
     if (status === "success") {
       // PhantomJS 2 has a memory consumption problem. This works around it.
       //


### PR DESCRIPTION
PhantomJS WebPage.open doesn't work when the url has no newline at the end.