### PR TITLE
Update compute_asset_path to Rails 4 signature

### DIFF
--- a/lib/jasmine_rails/offline_asset_paths.rb
+++ b/lib/jasmine_rails/offline_asset_paths.rb
@@ -6,7 +6,7 @@ module JasmineRails
   module OfflineAssetPaths
     mattr_accessor :disabled
 
-    def compute_asset_path(source, dir, options={})
+    def compute_asset_path(source, options={})
       return super if JasmineRails::OfflineAssetPaths.disabled
       source = source.to_s
       return source if source.empty? || source.starts_with?('/')
@@ -27,8 +27,8 @@ module JasmineRails
     end
 
     # For Rails 3.2 support
-    def compute_public_path(*args)
-      JasmineRails::OfflineAssetPaths.disabled ? super : compute_asset_path(*args)
+    def compute_public_path(source, dir, options={})
+      JasmineRails::OfflineAssetPaths.disabled ? super : compute_asset_path(source, options)
     end
 
   end


### PR DESCRIPTION
Fixes https://github.com/searls/jasmine-rails/issues/213

The JasmineRails::OfflineAssetPaths monkey patch of `compute_asset_path` has a Rails 3 signature:
https://github.com/searls/jasmine-rails/blob/master/lib/jasmine_rails/offline_asset_paths.rb#L9

This was updated from 3 arguments to 2 in Rails 4:
Rails 3: https://apidock.com/rails/ActionView/AssetPaths/compute_public_path
Rails 4: https://apidock.com/rails/ActionView/Helpers/AssetUrlHelper/compute_asset_path

If JasmineRails::OfflineAssetPaths.disabled is true, then the method is meant to shortcut and run the original super method. This gave an error like:

```
ActionView::Template::Error: wrong number of arguments (given 3, expected 1..2)
```

cc @h-lame