### PR TITLE
Allow to pass several options to PhantomJS via jasmine.yml. Fix #192

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ This will then try and use the `phantom` executable on the current `PATH`.
 If you want to pass command-line options to phantomjs executable, you can set:
 
 ```yml
-phantom_options: --web-security=no
+phantom_options: --web-security=no --debug=yes
 ```
 
 This will pass everything defined on `phantom_options` as

--- a/lib/jasmine-rails.rb
+++ b/lib/jasmine-rails.rb
@@ -102,8 +102,9 @@ module JasmineRails
       jasmine_config['use_phantom_gem'].nil? || jasmine_config['use_phantom_gem'] == true
     end
 
+    # @return [Array<String>]
     def phantom_options
-      jasmine_config['phantom_options'].to_s.strip
+      jasmine_config['phantom_options'].to_s.split(/\s+/).map(&:strip)
     end
 
     private

--- a/lib/jasmine_rails/runner.rb
+++ b/lib/jasmine_rails/runner.rb
@@ -19,8 +19,8 @@ module JasmineRails
 
           phantomjs_runner_path = File.join(File.dirname(__FILE__), '..', 'assets', 'javascripts', 'jasmine-runner.js')
           phantomjs_cmd = JasmineRails.use_phantom_gem? ? Phantomjs.path : 'phantomjs'
-          phantomjs_opts = JasmineRails.phantom_options
-          run_cmd %{"#{phantomjs_cmd}" "#{phantomjs_opts}" "#{phantomjs_runner_path}" "file://#{runner_path.to_s}?spec=#{spec_filter}"}
+          phantomjs_opts = JasmineRails.phantom_options.map { |option| "#{option}" }.join(' ')
+          run_cmd %{"#{phantomjs_cmd}" #{phantomjs_opts} "#{phantomjs_runner_path}" "file://#{runner_path.to_s}?spec=#{spec_filter}"}
         end
       end
 


### PR DESCRIPTION
Currently it doesn't work. See #192 

```yml
phantom_options: --debug=true --web-security=false
```