### PR TITLE
always use console log instead of error

### DIFF
--- a/lib/assets/javascripts/jasmine-runner.js
+++ b/lib/assets/javascripts/jasmine-runner.js
@@ -8,7 +8,7 @@
         msgStack.push(' -> ' + t.file + ': ' + t.line + (t.function ? ' (in function "' + t.function + '")' : ''));
       });
     }
-    console.error(msgStack.join('\n'));
+    console.log(msgStack.join('\n'));
     phantom.exit(1);
   };
   phantom.onError = errorHandler;


### PR DESCRIPTION
It seams that onError catches console.error and this create a circular invokation.
Maybe we could redirect all in stdout, this is a solution and works well
