### PR TITLE
Update Travis to Ruby 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.0
+  - 2.1
   - 2.3.0
 gemfile:
   - gemfiles/rails-3.2
@@ -29,7 +29,7 @@ matrix:
       gemfile: gemfiles/rails-4.0-jasmine-2
     - rvm: 2.3.0
       gemfile: gemfiles/rails-4.1
-    - rvm: 2.0
+    - rvm: 2.1
       gemfile: gemfiles/rails-5.0
-    - rvm: 2.0
+    - rvm: 2.1
       gemfile: gemfiles/rails-5-sprockets-4


### PR DESCRIPTION
This would fix the Rails 4 builds on Travis, but freezing turbolinks on 5.0 would also fix it.

I'm not an expert here, but I predict going forward is the right thing to do.