### PR TITLE
Freeze turbolinks in Rails 4

### DIFF
--- a/gemfiles/rails-4.0
+++ b/gemfiles/rails-4.0
@@ -7,7 +7,7 @@ gem 'rails', '~> 4.0.0'
 gem 'mime-types', '< 3'
 gem 'coffee-rails', '~> 4.0.0'
 gem 'sass-rails', '~> 4.0.0'
-gem 'turbolinks'
+gem 'turbolinks', '~> 5.0.1'
 
 gem "jquery-rails"
 gem "sqlite3"

--- a/gemfiles/rails-4.0-jasmine-2
+++ b/gemfiles/rails-4.0-jasmine-2
@@ -7,7 +7,7 @@ gem 'rails', '~> 4.0.0'
 gem 'mime-types', '< 3'
 gem 'coffee-rails', '~> 4.0.0'
 gem 'sass-rails', '~> 4.0.0'
-gem 'turbolinks'
+gem 'turbolinks', '~> 5.0.1'
 
 gem "jquery-rails"
 gem "sqlite3"

--- a/gemfiles/rails-4.1
+++ b/gemfiles/rails-4.1
@@ -13,7 +13,7 @@ gem 'sqlite3'
 gem 'jasmine-core', '~> 1.3'
 
 # gem 'uglifier', '>= 1.3.0'
-# gem 'turbolinks'
+gem 'turbolinks', '~> 5.0.1'
 # gem 'jbuilder', '~> 2.0'
 # gem 'sdoc', '~> 0.4.0',          group: :doc
 # gem 'spring',        group: :development


### PR DESCRIPTION
This would fix the Rails 4 builds on Travis, but upgrading to Ruby 2.1 would also fix the issue.

I'm not an expert here, but I predict going forward this isn't the right approach.