### PR TITLE
fix travis on rails-5.0 and rails-5-sprockets-4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 2.1
   - 2.3.0
 gemfile:
   - gemfiles/rails-3.2
@@ -18,18 +17,3 @@ before_install:
   - "sh -e /etc/init.d/xvfb start"
 
 script: './run-tests.rb'
-
-matrix:
-  exclude:
-    - rvm: 2.3.0
-      gemfile: gemfiles/rails-3.2
-    - rvm: 2.3.0
-      gemfile: gemfiles/rails-4.0
-    - rvm: 2.3.0
-      gemfile: gemfiles/rails-4.0-jasmine-2
-    - rvm: 2.3.0
-      gemfile: gemfiles/rails-4.1
-    - rvm: 2.1
-      gemfile: gemfiles/rails-5.0
-    - rvm: 2.1
-      gemfile: gemfiles/rails-5-sprockets-4

--- a/gemfiles/rails-3.2
+++ b/gemfiles/rails-3.2
@@ -11,6 +11,7 @@ gem 'coffee-script'
 gem 'jasmine-core', '~> 1.3'
 
 group :test do
+  gem 'test-unit'
   gem 'rspec-rails'
   gem 'capybara'
   gem 'poltergeist'

--- a/gemfiles/rails-5-sprockets-4
+++ b/gemfiles/rails-5-sprockets-4
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gemspec path: File.expand_path('..', File.dirname(__FILE__))
 
 gem 'rails', '~> 5.0.0'
+gem 'puma'
 gem 'sprockets', '4.0.0.beta2'
 gem 'coffee-rails'
 

--- a/gemfiles/rails-5.0
+++ b/gemfiles/rails-5.0
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gemspec path: File.expand_path('..', File.dirname(__FILE__))
 
 gem 'rails', '~> 5.0.0'
+gem 'puma'
 gem 'coffee-rails'
 gem 'sass-rails'
 


### PR DESCRIPTION
Travis is failing on rails 5.0 and rails 5-sprockets-4 variants because of a missing puma from the Gemfile.