### PR TITLE
fix deprecation warning on Rails 5.2

### DIFF
--- a/lib/jasmine_rails/runner.rb
+++ b/lib/jasmine_rails/runner.rb
@@ -64,7 +64,7 @@ module JasmineRails
         end
 
         JasmineRails::OfflineAssetPaths.disabled = true
-        unless app.response.success?
+        unless app.response.successful?
           raise "Jasmine runner at '#{path}' returned a #{app.response.status} error: #{app.response.message} \n\n" +
                 "The most common cause is an asset compilation failure. Full HTML response: \n\n #{app.response.body}"
         end


### PR DESCRIPTION
`DEPRECATION WARNING: The success? predicate is deprecated and will be removed in Rails 6.0. Please use successful? as provided by Rack::Response::Helpers.`

(this is equivalent to #229 but rebased on master)