### PR TITLE
Make spec_dir globbing relative to Rails.root

### DIFF
--- a/lib/jasmine-rails.rb
+++ b/lib/jasmine-rails.rb
@@ -23,7 +23,7 @@ module JasmineRails
 
     def spec_dir
       paths = jasmine_config['spec_dir'] || 'spec/javascripts'
-      [paths].flatten.map { |path| Dir.glob path }.flatten.collect { |path| Rails.root.join(path) }
+      [paths].flatten.collect { |path| Pathname.glob Rails.root.join(path) }.flatten
     end
 
     def include_dir


### PR DESCRIPTION
This makes it possible to use jasmine-rails from within another engine, where Rails.root is pointing at the dummy project, but the specs are in the engine. This is an alternative to #227.